### PR TITLE
Add support for finding cert from config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,6 +3,8 @@ balrog:
     username: null
     password: null
     api_root: https://aus4-admin-dev.allizom.org/api
+    # usually needed if using https://aus4-admin.mozilla.org/api as the api_root
+    # cert: funsize/data/mozilla-root.crt
 
 pulse:
     user: null

--- a/funsize/balrog.py
+++ b/funsize/balrog.py
@@ -15,7 +15,7 @@ class BalrogClient(object):
         self.api_root = api_root
         self.auth = auth
         if cert:
-            self.verify = os.path.join(os.path.dirname(__file__), 'data', cert)
+            self.verify = cert
         else:
             self.verify = True
 

--- a/funsize/scheduler.py
+++ b/funsize/scheduler.py
@@ -51,7 +51,8 @@ def main():
     else:
         tc_opts = config["taskcluster"]
 
-    balrog_client = BalrogClient(api_root=api_root, auth=auth)
+    cert = config["balrog"].get("cert")
+    balrog_client = BalrogClient(api_root=api_root, auth=auth, cert=cert)
     scheduler = taskcluster.Scheduler(tc_opts)
 
     with Connection(hostname='pulse.mozilla.org', port=5671,


### PR DESCRIPTION
We need this (or something like it) to make it possible to use aus4-admin.mozilla.org in production. The current code has support for using a cert bundle, but there's no way to enable it (you have to set cert=True when instantiating BalrogClient, and there's no way to do that with the current code). I thought about adding a use_internal_cert (or whatever) flag to the config, but it seemed to me that having the config point at a specific cert rather than trigger some hardcoding would be better. I'm happy to do whatever you think is best here, though.